### PR TITLE
feat: add vector of Scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 - (nothing to record)
 
+## [0.1.1] - 2021-04-22
+### Added
+- Add `vector`:
+  - add Rus3::Vector class,
+  - modify Rus3::Parser::Lexer to accept a vector literal,
+  - modify Rus3::Parser::SchemeParser to parse and translate a vector
+    literal,
+- Add new error classes (VectorRequiredError and ExceedUpperLimitError),
+- Add tests around `vector`.
+
+### Changed
+- Modify Rus3::Parser::Lexer to convert "->" to "_to_",
+  - now, the Scheme identifier such "list->vector" is usable in the
+    REPL
+
 ## [0.1.0] - 2021-04-21
 - Initial release:
   - Rus3 can translate fundamental syntax of Scheme into Ruby.
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rus3 (0.1.0)
+    rus3 (0.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Rus3(scheme)> 1/9
 ==> (1/9)
 Rus3(scheme)> 3+4i
 ==> (3+4i)
+Rus3(scheme)> #(1 2 3)
+==> #<Rus3::Vector:0x00007facf12d9fb0 @content=[1, 2, 3]>
 ```
 
 ### Procedure call
@@ -115,8 +117,8 @@ Following procedures described in the spec is available.
 - Predicates:
   - null?, list?
   - eqv?, eq?
-  - boolean?, pair?, symbol?, number?, string?
-    - char?, vector?, and port? are defined but it always returns `false`.
+  - boolean?, pair?, symbol?, number?, string?, vector?
+    - char? and port? are defined but it always returns `false`.
   - complex?, real?, rational?, integer?
   - zero?, positive?, negative?, odd?, even?
   - string-eq?, string-ci-eq?, string-lt?, string-gt?, string-le?,
@@ -127,6 +129,10 @@ Following procedures described in the spec is available.
 - List operations
   - cons, car, cdr, set-car!, set-cdr!, cxxr (caar and so on)
   - list, length, append, reverse, list-tail, list-ref
+
+- Vector operations
+  - make-vector, vector, vector-length, vector-ref, vector-set!,
+    vector->list, list->vector, vector-fill!
 
 - Write values
   - write

--- a/exe/rus3
+++ b/exe/rus3
@@ -2,4 +2,17 @@
 
 require "rus3"
 
-Rus3::Repl.start(verbose: ARGV.size > 0)
+opts = {}
+
+while ARGV.size > 0
+  arg = ARGV.shift
+  case arg
+  when "-d", "--debug"
+    opts[:debug] = true
+  when "-v", "--version"
+    puts "rus3 version #{Rus3::VERSION} (#{Rus3::RELEASE})"
+    exit 0
+  end
+end
+
+Rus3::Repl.start(verbose: opts[:debug])

--- a/lib/rus3.rb
+++ b/lib/rus3.rb
@@ -39,9 +39,12 @@ module Rus3
   require_relative "rus3/pair"
   require_relative "rus3/char"
   require_relative "rus3/port"
+  require_relative "rus3/vector"
 
+  require_relative "rus3/procedure/utils"
   require_relative "rus3/procedure/predicate"
   require_relative "rus3/procedure/list"
+  require_relative "rus3/procedure/vector"
   require_relative "rus3/procedure/control"
   require_relative "rus3/procedure/write"
 

--- a/lib/rus3/error.rb
+++ b/lib/rus3/error.rb
@@ -11,12 +11,14 @@ module Rus3
           "()"
         else                    # a normal proper list
           list_notation = obj.to_s().gsub(/[\[\],]/, A2L_MAP)
-          "list( %s )" % obj
+          "list( %s )" % list_notation
         end
       when Numeric
         "number(%d)" % obj
       when Rus3::Pair
         "pair(%s)" % obj
+      when Rus3::Vector
+        "vector(%s)" % obj
       else
         "%s(%s)" % [obj.class, obj]
       end
@@ -31,7 +33,9 @@ module Rus3
     :pair_required => "pair required: got=%s",
     :list_required => "proper list required: got=%s",
     :pair_or_list_required => "pair or proper list required: got=%s",
+    :vector_required => "vector required: got=%s",
     :out_of_range  => "argument out of range: got=%s",
+    :exceed_upper_limit => "argument exceeds its upper limit (%d): got=%d",
     :unsupported_method => "specified method does not work now.",
     :wrong_type => "wrong type argument: got=%s, wants=%s",
     :integer_required => "integer required: got=%s",
@@ -63,9 +67,21 @@ module Rus3
     end
   end
 
+  class VectorRequiredError < Error
+    def initialize(obj)
+      super(EMSG[:vector_required] % smart_error_value(obj))
+    end
+  end
+
   class OutOfRangeError < Error
     def initialize(obj)
       super(EMSG[:out_of_range] % smart_error_value(obj))
+    end
+  end
+
+  class ExceedUpperLimitError < Error
+    def initialize(value, limit)
+      super(EMSG[:exceed_upper_limit] % [limit, value])
     end
   end
 

--- a/lib/rus3/evaluator.rb
+++ b/lib/rus3/evaluator.rb
@@ -14,6 +14,7 @@ module Rus3
     class Environment
       include Rus3::Procedure::Control
       include Rus3::Procedure::Write
+      include Rus3::Procedure::Vector
       include Rus3::Procedure::List
       include Rus3::Procedure::Predicate
       include Rus3::EmptyList

--- a/lib/rus3/parser/lexer.rb
+++ b/lib/rus3/parser/lexer.rb
@@ -5,7 +5,7 @@ module Rus3::Parser
   class Lexer < Enumerator
 
     # Indicates the version of the lexer class
-    LEXER_VERSION = "0.1.0"
+    LEXER_VERSION = "0.1.1"
 
     # :stopdoc:
 
@@ -13,6 +13,7 @@ module Rus3::Parser
       # delimiters
       :lparen,
       :rparen,
+      :vec_lparen,
       # value types
       :boolean,
       :ident,
@@ -31,12 +32,12 @@ module Rus3::Parser
     STRING     = /\A\"[^\"]*\"\Z/
 
     # idents
-    EXTENDED   = "\\-"
+    EXTENDED   = "\\->"
     IDENT_PAT  = "[a-zA-Z_][\\w?!#{EXTENDED}]*"
     IDENTIFIER = Regexp.new("\\A#{IDENT_PAT}\\Z")
 
     EXTENDED_REGEXP = Regexp.new("[#{EXTENDED}]")
-    EXTENDED_MAP = { "-" => "_", }
+    EXTENDED_MAP = { "-" => "_", ">" => "to_"}
 
     # operators
     ARITHMETIC_OPS = /\A[+\-*\/%]\Z/
@@ -90,6 +91,8 @@ module Rus3::Parser
             Token.new(:lparen, literal)
           when "]"
             Token.new(:rparen, literal)
+          when "#["
+            Token.new(:vec_lparen, literal)
           when BOOLEAN
             Token.new(:boolean, literal)
           when IDENTIFIER

--- a/lib/rus3/procedure/list.rb
+++ b/lib/rus3/procedure/list.rb
@@ -11,12 +11,13 @@ module Rus3::Procedure
 
   module List
 
+    include Utils
     include Predicate
     include Rus3::EmptyList
 
     # Constructs a Pair object with arguments.
     #
-    #   - R5RS procedure: (cons obj1 obj2)
+    #   - procedure (R5RS): (cons obj1 obj2)
 
     def cons(obj1, obj2)
       case obj2
@@ -36,7 +37,7 @@ module Rus3::Procedure
     # Returns the CAR part of the argument.  If the arguemnt is not
     # a pair, raises PairRequiredError.
     #
-    #   - R5RS procedure: (car pair)
+    #   - procedure (R5RS): (car pair)
 
     def car(pair)
       case pair
@@ -53,7 +54,7 @@ module Rus3::Procedure
     # Returns the CDR part of the argument.  If the arguemnt is not
     # a pair, raises PairRequiredError.
     #
-    #   - R5RS procedure: (cdr pair)
+    #   - procedure (R5RS): (cdr pair)
 
     def cdr(pair)
       case pair
@@ -70,7 +71,7 @@ module Rus3::Procedure
     # Replaces the CAR part with the 2nd argument and returns UNDEF.
     # If the 1st arguemnt is not a pair, raises PairRequiredError.
     #
-    #   - R5RS procedure: (set-car! pair obj)
+    #   - procedure (R5RS): (set-car! pair obj)
 
     def set_car!(pair, obj)
       case pair
@@ -87,7 +88,7 @@ module Rus3::Procedure
     # Replaces the CDR part with the 2nd argument and returns UNDEF.
     # If the 1st arguemnt is not a pair, raises PairRequiredError.
     #
-    #   - R5RS procedure: (set-cdr! pair obj)
+    #   - procedure (R5RS): (set-cdr! pair obj)
 
     def set_cdr!(pair, obj)
       case pair
@@ -113,8 +114,8 @@ module Rus3::Procedure
 
     # Retrieves the CAR part of the CAR part of the given pair.
     #
-    #   - R5RS library procedure: (caar pair)
-    #   - R7RS procedure: (caar pair)
+    #   - library procedure (R5RS): (caar pair)
+    #   - procedure (R7RS): (caar pair)
 
     def caar(pair)
       car(car(pair))
@@ -122,8 +123,8 @@ module Rus3::Procedure
 
     # Retrieves the CAR part of the CDR part of the given pair.
     #
-    #   - R5RS library procedure: (cadr pair)
-    #   - R7RS procedure: (cadr pair)
+    #   - library procedure (R5RS): (cadr pair)
+    #   - procedure (R7RS): (cadr pair)
 
     def cadr(pair)
       car(cdr(pair))
@@ -131,8 +132,8 @@ module Rus3::Procedure
 
     # Retrieves the CDR part of the CAR part of the given pair.
     #
-    #   - R5RS library procedure: (cdar pair)
-    #   - R7RS procedure: (cdar pair)
+    #   - library procedure (R5RS): (cdar pair)
+    #   - procedure (R7RS): (cdar pair)
 
     def cdar(pair)
       cdr(car(pair))
@@ -140,8 +141,8 @@ module Rus3::Procedure
 
     # Retrieves the CDR part of the CDR part of the given pair.
     #
-    #   - R5RS library procedure: (cddr pair)
-    #   - R7RS procedure: (cddr pair)
+    #   - libbrary procedure (R5RS): (cddr pair)
+    #   - procedure (R7RS): (cddr pair)
 
     def cddr(pair)
       cdr(cdr(pair))
@@ -149,15 +150,14 @@ module Rus3::Procedure
 
     # :stopdoc:
 
-    #    - R7RS: procedure: (make-list k)
-
-    #    - R7RS: procedure: (make-list k fill)
+    #    - procedure (R7RS): (make-list k)
+    #    - procedure (R7RS): (make-list k fill)
 
     # :startdoc:
 
     # Constructs a list from arguments in its order.
     #
-    #   - R5RS library procedure: (list obj ...)
+    #   - library procedure (R5RS): (list obj ...)
 
     def list(*objs)
       Array[*objs]
@@ -166,8 +166,8 @@ module Rus3::Procedure
     # Returns the length of the arguemnt.  If the argument is not a
     # proper list, raises ListRequiredError.
     #
-    #   - R5RS library procedure: (length list)
-    #   - R7RS procedure: (length list)
+    #   - library procedure (R5RS): (length list)
+    #   - procedure (R7RS): (length list)
 
     def length(lst)
       check_list(lst)
@@ -177,8 +177,8 @@ module Rus3::Procedure
     # Concatenates given lists into a single list.  Each argument
     # must be a proper list, otherwise raises ListRequiredError.
     #
-    #   - R5RS library procedure: (append list ...)
-    #   - R7RS procedure: (append list ...)
+    #   - library procedure (R5RS): (append list ...)
+    #   - procedure (R7RS): (append list ...)
 
     def append(*lists)
       lists.each { |lst|
@@ -189,8 +189,8 @@ module Rus3::Procedure
 
     # Returns a list of the same elements in reverse order.
     #
-    #   - R5RS library procedure: (reverse list)
-    #   - R7RS procedure: (reverse list)
+    #   - library procedure (R5RS): (reverse list)
+    #   - procedure (R7RS): (reverse list)
 
     def reverse(lst)
       check_list(lst)
@@ -199,12 +199,12 @@ module Rus3::Procedure
 
     # Returns the sublist of the arguemnt by omitting the first k
     # elements.  The 2nd argument, k must be in 0..length(lst),
-    # otherwise raises OutOfRangeError.
+    # otherwise raises ExceedUppeerLimitError.
     #
     # This implementation logic comes from R5RS 6.3.2.
     #
-    #   - R5RS library procedure: (list-tail list k)
-    #   - R7RS procedure: (list-tail list k)
+    #   - library procedure (R5RS): (list-tail list k)
+    #   - procedure (R7RS): (list-tail list k)
 
     def list_tail(lst, k)
       check_list(lst)
@@ -214,10 +214,10 @@ module Rus3::Procedure
     end
 
     # Returns kth element of the argument.  k must be less than the
-    # length of the list, otherwise, raises OutOfRangeError.
+    # length of the list, otherwise, raises ExceedUppeerLimitError.
     #
-    #   - R5RS library procedure: (list-ref list k)
-    #   - R7RS procedure: (list-ref list k)
+    #   - library procedure (R5RS): (list-ref list k)
+    #   - procedure (R7RS): (list-ref list k)
 
     def list_ref(lst, k)
       check_list(lst)
@@ -228,62 +228,45 @@ module Rus3::Procedure
 
     # :stopdoc:
 
-    #   - R7RS procedure: (list-set! list k obj)
+    #   - procedure (R7RS): (list-set! list k obj)
 
     # :startdoc:
 
     # :stopdpc:
 
-    #   - R5RS library procedure: (memq obj list)
-    #   - R7RS procedure: (memq obj list)
+    #   - library procedure (R5RS): (memq obj list)
+    #   - procedure (R7RS): (memq obj list)
 
-    #   - R5RS library procedure: (memv obj list)
-    #   - R7RS procedure: (memv obj list)
+    #   - library procedure (R5RS): (memv obj list)
+    #   - procedure (R7RS): (memv obj list)
 
-    #   - R5RS library procedure: (member obj list)
-    #   - R7RS procedure: (member obj list)
+    #   - library procedure (R5RS): (member obj list)
+    #   - procedure (R7RS): (member obj list)
 
-    #   - R7RS procedure: (member obj list compare)
+    #   - procedure (R7RS): (member obj list compare)
 
     # :startdoc:
 
     # :stopdpc:
 
-    #   - R5RS library procedure: (assq obj alist)
-    #   - R7RS procedure: (assq obj alist)
+    #   - library procedure (R5RS): (assq obj alist)
+    #   - procedure (R7RS): (assq obj alist)
 
-    #   - R5RS library procedure: (assv obj alist)
-    #   - R7RS procedure: (assv obj alist)
+    #   - library procedure (R5RS): (assv obj alist)
+    #   - procedure (R7RS): (assv obj alist)
 
-    #   - R5RS library procedure: (assoc obj alist)
-    #   - R7RS procedure: (assoc obj alist)
+    #   - library procedure (R5RS): (assoc obj alist)
+    #   - procedure (R7RS): (assoc obj alist)
 
-    #   - R7RS procedure: (assoc obj alist compare)
+    #   - procedure (R7RS): (assoc obj alist compare)
 
     # :startdoc:
 
     # :stopdoc:
 
-    #   - R7RS procedure: (list-copy obj)
+    #   - procedure (R7RS): (list-copy obj)
 
     # :startdoc:
-
-    private
-
-    def check_pair(pair)      # :nodoc:
-      if !pair.instance_of?(Rus3::Pair) and !pair.instance_of?(Array)
-        raise Rus3::PairRequiredError, pair
-      end
-    end
-
-    def check_list(lst)       # :nodoc:
-      raise Rus3::ListRequiredError, lst unless list?(lst)
-    end
-
-    # To make sure the number is less than its upper limit.
-    def check_upper_limit(k, limit) # :nodoc:
-      raise Rus3::OutOfRangeError, k if k >= limit
-    end
 
   end
 end

--- a/lib/rus3/procedure/predicate.rb
+++ b/lib/rus3/procedure/predicate.rb
@@ -44,12 +44,12 @@ module Rus3::Procedure
     # provides some classes for the rest of them.
     #
     #   boolean? ---> FalseClass or TrueClass
-    #   pair? ------> Rus3::Pair
+    #   pair? ------> Array (as a list) or Rus3::Pair (as a dotted pair)
     #   symbol? ----> Symbol
     #   number? ----> Numeric
     #   char? ------> Rus3::Char
     #   string? ----> String
-    #   vector? ----> Array
+    #   vector? ----> Rus3::Vector
     #   port? ------> Rus3::Port
     #   procedure? -> Proc
 
@@ -64,11 +64,11 @@ module Rus3::Procedure
     end
 
     def symbol?(obj)
-      obj.is_a?(Symbol) && obj != Rus3::UNDEF
+      obj.instance_of?(Symbol) && obj != Rus3::UNDEF
     end
 
     def number?(obj)
-      obj.is_a?(Numeric)
+      obj.kind_of?(Numeric)
     end
 
     def char?(obj)
@@ -79,8 +79,9 @@ module Rus3::Procedure
       obj.kind_of?(String)
     end
 
+    # procedure (R5RS/R7RS): (vector? obj)
     def vector?(obj)
-      false
+      obj.instance_of?(Rus3::Vector)
     end
 
     def port?(obj)

--- a/lib/rus3/procedure/utils.rb
+++ b/lib/rus3/procedure/utils.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Rus3::Procedure
+  module Utils
+
+    def check_pair(pair)        # :nodoc:
+      if !pair.instance_of?(Rus3::Pair) and !pair.instance_of?(Array)
+        raise Rus3::PairRequiredError, pair
+      end
+    end
+
+    def check_list(lst)         # :nodoc:
+      raise Rus3::ListRequiredError, lst unless list?(lst)
+    end
+
+    def check_vector(obj)       # :nodoc:
+      raise Rus3::VectorRequiredError, obj unless vector?(obj)
+    end
+
+    # To make sure the number is less than its upper limit.  When k
+    # greater than or equal to limit, raises ExceedUpperLimitError.
+
+    def check_upper_limit(k, limit)
+      raise Rus3::ExceedUpperLimitError.new(k, limit) if k >= limit
+    end
+
+  end
+end

--- a/lib/rus3/procedure/vector.rb
+++ b/lib/rus3/procedure/vector.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Rus3::Procedure
+
+  # Provides procedures to operate a vector.
+
+  module Vector
+
+    include Utils
+    include List
+    include Predicate
+    include Rus3::EmptyList
+
+    UNDEF = Rus3::UNDEF
+
+    #   - procedure (R5RS/R7RS): (make-vector k) or (make-vector k fill)
+
+    def make_vector(k, fill = UNDEF)
+      Rus3::Vector.new(k, fill)
+    end
+
+    #   - library procedure (R5RS/R7RS): (vector obj ...)
+
+    def vector(*objs)
+      Rus3::Vector.vector(*objs)
+    end
+
+    #   - procedure (R5RS/R7RS): (vector-length vector)
+
+    def vector_length(vec)
+      check_vector(vec)
+      vec.length
+    end
+
+    #   - procedure (R5RS/R7RS): (vector-ref vector, k)
+
+    def vector_ref(vec, k)
+      check_vector(vec)
+      check_upper_limit(k, vec.length)
+      vec.ref(k)
+    end
+
+    #   - procedure (R5RS/R7RS): (vector-set! vector k obj)
+
+    def vector_set!(vec, k, obj)
+      check_vector(vec)
+      Rus3::Vector.vector_set!(vec, k, obj)
+    end
+
+    #   - library procedure (R5RS): (vector->list vector)
+    #   - procedure (R7RS):
+    #       (vector->list vector)
+    #       (vector->list vector start)
+    #       (vector->list vector start end)
+
+    def vector_to_list(vec, start_index = 0, end_index = -1)
+      end_index = vec.length if end_index == -1
+
+      check_vector(vec)
+      check_limits(start_index, end_index, vec.length)
+
+      list(*vec.ref(start_index...end_index))
+    end
+
+    #   - library procedure (R5RS): (list->vector list)
+    #   - procedre (R7RS): (list->vector list)
+
+    def list_to_vector(lst)
+      Rus3::Vector.list_to_vector(lst)
+    end
+
+    #   - library procedure (R5RS): (vector-fill! vector fill)
+    #   - procedure (R7RS): (vector-fill! vector fill start end)
+
+    def vector_fill!(vec, fill, start_index = 0, end_index = -1)
+      end_index = vec.length if end_index == -1
+
+      check_vector(vec)
+      check_limits(start_index, end_index, vec.length)
+
+      start_index.upto(end_index - 1) {|i| vec.set!(i, fill)}
+    end
+
+    # :stopdoc:
+
+    private
+
+    # Makes sure that start_index < end_index <= limit.
+    def check_limits(start_index, end_index, limit)
+      check_upper_limit(start_index, limit)
+      check_upper_limit(start_index, end_index)
+      check_upper_limit(end_index, limit + 1)
+    end
+
+    # :startdoc:
+
+  end
+end

--- a/lib/rus3/repl.rb
+++ b/lib/rus3/repl.rb
@@ -97,7 +97,9 @@ module Rus3
     # Shows the greeting message.
     def greeting
       puts "A simple REPL for Rus3:"
-      puts "- Rus3 version: #{Rus3::VERSION}"
+      puts "- Rus3 version: #{Rus3::VERSION} (#{Rus3::RELEASE})"
+      return unless @verbose
+
       puts "  - REPL version: #{VERSION}"
       COMPONENTS.keys.each { |comp_name|
         Kernel.print "    - "

--- a/lib/rus3/vector.rb
+++ b/lib/rus3/vector.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "forwardable"
+
+module Rus3
+
+  # A class to represent a vector structure of Scheme.
+
+  class Vector
+    extend Forwardable
+
+    class << self
+      # Returns a new Vector instance which elements are the given objs.
+      def vector(*objs)
+        list_to_vector(objs)
+      end
+
+      # Converts a list into a new Vector instance.
+      def list_to_vector(lst)
+        vec = self.new(lst.size)
+        lst.each_with_index {|e, i| vec.set!(i, e)}
+        vec
+      end
+
+      # Converts a Vector instance into a list.
+      def vector_to_list(vec)
+        vec.to_a
+      end
+
+      # Replaces the k-th element of the given vector with obj.
+      def vector_set!(vec, k, obj)
+        raise ExceedUpperLimitError.new(k, vec.length) if k >= vec.length
+        vec.set!(k, obj)
+      end
+
+    end
+
+    def initialize(k, fill = UNDEF)
+      @content = Array.new(k, fill)
+    end
+
+    def_delegator :@content, :[], :ref
+    def_delegator :@content, :[]=, :set!
+    def_delegator :@content, :size, :length
+
+    # Returns an Array instance which contains the vector contents.
+    def to_a
+      @content.dup
+    end
+
+    # Converts a string represents as a Scheme vector.
+    def to_s
+      "#(#{@content.join(' ')})"
+    end
+
+  end
+end

--- a/lib/rus3/version.rb
+++ b/lib/rus3/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module Rus3
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
+  RELEASE = "2021-04-22"
 end

--- a/test/rus3_parser_lexer_test.rb
+++ b/test/rus3_parser_lexer_test.rb
@@ -92,6 +92,16 @@ class Rus3ParserLexerTest < Minitest::Test
     assert_equal "]", token.literal
   end
 
+  # vector litral
+
+  def test_it_can_detect_vector_lpraen
+    l = Rus3::Parser::Lexer.new("#(")
+    token = l.next
+
+    assert_equal :vec_lparen, token.type
+    assert_equal "#[", token.literal
+  end
+
   # compound test
 
   def test_it_can_detect_tokens_properly

--- a/test/rus3_procedure_list_test.rb
+++ b/test/rus3_procedure_list_test.rb
@@ -198,7 +198,7 @@ class Rus3ProcedureListTest < Minitest::Test
   def test_list_tail_raises_an_error_when_2nd_argument_is_greather_than_length
     size = 7
     lst = prepare_list(520, size)
-    assert_raises(Rus3::OutOfRangeError) {
+    assert_raises(Rus3::ExceedUpperLimitError) {
       list_tail(lst, size + 1)
     }
   end
@@ -231,7 +231,7 @@ class Rus3ProcedureListTest < Minitest::Test
   def test_list_ref_raises_when_specified_larger_than_length_of_the_list
     size = 10
     lst = prepare_list(550, size)
-    assert_raises(Rus3::OutOfRangeError) {
+    assert_raises(Rus3::ExceedUpperLimitError) {
       list_ref(lst, size + 1)
     }
   end

--- a/test/rus3_procedure_vector_test.rb
+++ b/test/rus3_procedure_vector_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Rus3ProcedureVectorTest < Minitest::Test
+
+  include Rus3::Procedure::Vector
+
+  def test_new_vector_can_be_made_by_make_vecor_proc
+    k = 3
+    vec = make_vector(k)
+    refute vec.nil?
+    0.upto(k - 1) { |i|
+      assert_equal UNDEF, vec.ref(i)
+    }
+  end
+
+  def test_new_vector_can_be_made_by_vector_proc
+    ary = [100, 101, 102, 103]
+    vec = vector(*ary)
+    ary.each_with_index { |e, i|
+      assert_equal e, vec.ref(i)
+    }
+  end
+
+  def test_vector_length_works_to_a_vector
+    k = 5
+    vec = Rus3::Vector.new(k)
+    assert_equal k, vector_length(vec)
+  end
+
+  def test_each_element_can_be_referred_by_vector_ref
+    k = 6
+    fill = 200
+    vec = Rus3::Vector.new(k, fill)
+    1.upto(k).each {|i| vec.set!(i, fill + i)}
+
+    0.upto(k - 1).each { |i|
+      assert_equal (fill + i), vector_ref(vec, i)
+    }
+  end
+
+  def test_each_element_can_be_set_by_vector_set
+    k = 7
+    fill = 300
+    vec = Rus3::Vector.new(k, fill)
+
+    0.upto(k - 1).each { |i|
+      vector_set!(vec, i, fill + i)
+      assert_equal (fill + i), vec.ref(i)
+    }
+  end
+
+  def test_vector_to_list_can_convert_a_whole_vector
+    k = 8
+    fill = 400
+    vec = Rus3::Vector.new(k, fill)
+    0.upto(k - 1).each {|i| vec.set!(i, fill + i)}
+
+    lst = vector_to_list(vec)
+    0.upto(k - 1).each { |i|
+      assert_equal (fill + i), car(lst)
+      lst = cdr(lst)
+    }
+  end
+
+  def test_vector_to_list_can_make_a_list_from_a_part_of_vector
+    k = 9
+    fill = 500
+    vec = Rus3::Vector.new(k, fill)
+    0.upto(k - 1).each {|i| vec.set!(i, fill + i)}
+
+    lst = vector_to_list(vec, 1, k - 1)
+    1.upto(k - 2).each { |i|
+      assert_equal (fill + i), car(lst)
+      lst = cdr(lst)
+    }
+  end
+
+  def test_vector_to_list_raises_when_a_given_index_exceeds
+    k = 10
+    vec = Rus3::Vector.new(k)
+    assert_raises(Rus3::ExceedUpperLimitError) {
+      vector_to_list(vec, k, k)
+    }
+  end
+
+  def test_list_to_vector_can_convert_a_list
+    ary = [600, 601, 602, 603, 604]
+    lst = list(*ary)
+    vec = list_to_vector(lst)
+    ary.each_with_index { |e, i|
+      assert_equal e, vec.ref(i)
+    }
+  end
+
+  def test_vector_fill_can_fill_a_whole_vector_elements
+    k = 11
+    fill = 700
+    vec = Rus3::Vector.new(k)
+
+    vector_fill!(vec, fill)
+
+    0.upto(k - 1).each { |i|
+      assert_equal fill, vec.ref(i)
+    }
+  end
+
+  def test_vector_fill_can_fill_a_part_of_vector
+    k = 12
+    fill = 800
+    vec = Rus3::Vector.new(k)
+
+    s = 1
+    e = k - 1
+
+    vector_fill!(vec, fill, s, e)
+
+    refute_equal fill, vec.ref(0)
+    s.upto(e - 1).each { |i|
+      assert_equal fill, vec.ref(i)
+    }
+    refute_equal fill, vec.ref(k - 1)
+  end
+
+  def test_vector_fill_raises_when_a_given_index_exceeds
+    k = 13
+    vec = Rus3::Vector.new(k)
+    assert_raises(Rus3::ExceedUpperLimitError) {
+      vector_fill!(vec, 0, k - 1, 0)
+    }
+  end
+
+end

--- a/test/rus3_vector_test.rb
+++ b/test/rus3_vector_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Rus3VectorTest < Minitest::Test
+
+  include Rus3::Procedure::List
+
+  def test_it_can_be_instantiated_by_new
+    vec = Rus3::Vector.new(3)
+    refute vec.nil?
+  end
+
+  def test_it_can_refers_its_element_with_index
+    k = 5
+    fill = 8
+    vec = Rus3::Vector.new(k, fill)
+    0.upto(k - 1) { |i|
+      assert_equal fill, vec.ref(i)
+    }
+  end
+
+  def test_it_can_set_its_element_with_index
+    k = 6
+    fill = 9
+    vec = Rus3::Vector.new(k, fill)
+    0.upto(k - 1) { |i|
+      vec.set!(i, fill + i)
+      assert_equal fill + i, vec.ref(i)
+    }
+  end
+
+  def test_it_can_get_its_length
+    k = 7
+    fill = 10
+    vec = Rus3::Vector.new(k, fill)
+    assert_equal k, vec.length
+  end
+
+  def test_it_can_be_made_by_vector_proc
+    vec = Rus3::Vector.vector(1, "two", 3)
+    refute vec.nil?
+    assert_instance_of Rus3::Vector, vec
+  end
+
+  def test_it_can_be_made_from_a_list
+    vec = Rus3::Vector.list_to_vector(list(4, 5, 6))
+    refute vec.nil?
+    assert_instance_of Rus3::Vector, vec
+  end
+
+  def test_it_can_be_converted_to_a_list
+    vec = Rus3::Vector.new(5, 7)
+    lst = Rus3::Vector.vector_to_list(vec)
+    refute lst.nil?
+    assert_instance_of Array, lst
+  end
+
+  def test_it_raises_if_exceeded_index_is_given_to_vector_set
+    k = 8
+    fill = 11
+    vec = Rus3::Vector.new(k, fill)
+    assert_raises(Rus3::ExceedUpperLimitError) {
+      Rus3::Vector.vector_set!(vec, k, 0)
+    }
+  end
+
+  def test_it_can_be_converted_to_an_array
+    a = [100, 101, 102]
+    vec = Rus3::Vector.vector(*a)
+    b = vec.to_a
+    refute b.nil?
+    assert_instance_of Array, b
+    a.each_with_index { |e, i|
+      assert_equal e, b[i]
+    }
+  end
+
+  def test_it_can_be_converted_to_an_string
+    a = [110, 111, 112, 113, 114]
+    vec = Rus3::Vector.vector(*a)
+    str = vec.to_s
+
+    assert_equal "#(", str[0..1]
+    assert_equal ")", str[-1]
+
+    elements = str[2..-2].split(" ")
+    a.each_with_index { |e, i|
+      assert_equal e.to_s, elements[i]
+    }
+  end
+
+end


### PR DESCRIPTION
- add Rus3::Vector and Rus3::Procedure::Vector
  - modify Rus3::Parser::Lexer and Rus3::Parser::SchemeParser to
    accept a vector literal
  - add new error classes (VectorRequiredError and
    ExceedUpperLimitError)
  - add tests for vector and its operations
- modify Rus3::Parser::Lexer to convert "->" to "_to_"
- update README.md about vector
- bump version: 0.1.0 -> 0.1.1