### PR TITLE
feat: add char of Scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 - (nothing to record)
 
+## [0.1.2] - 2021-04-23
+### Added
+- Add `char`:
+  - add Rus3::Char class,
+  - modify Rus3::Parser::Lexer to accept a character literal,
+  - modify Rus3::Parser::SchemeParser to parse and translate a
+    character literal,
+- Add new error classes (CharRequiredError),
+- Add tests around `char`.
+
 ## [0.1.1] - 2021-04-22
 ### Added
 - Add `vector`:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rus3 (0.1.1)
+    rus3 (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Rus3(scheme)> 3+4i
 ==> (3+4i)
 Rus3(scheme)> #(1 2 3)
 ==> #<Rus3::Vector:0x00007facf12d9fb0 @content=[1, 2, 3]>
+Rus3(scheme)> #\a
+==> #<Rus3::Char:0x00007fc41f1059d8
+ @char="a",
+ @codepoint=97,
+ @encoding=#<Encoding:UTF-8>>
 ```
 
 ### Procedure call
@@ -117,14 +122,18 @@ Following procedures described in the spec is available.
 - Predicates:
   - null?, list?
   - eqv?, eq?
-  - boolean?, pair?, symbol?, number?, string?, vector?
-    - char? and port? are defined but it always returns `false`.
+  - boolean?, pair?, symbol?, number?, string?, vector?, char?
+    - port? are defined but it always returns `false`.
   - complex?, real?, rational?, integer?
   - zero?, positive?, negative?, odd?, even?
   - string-eq?, string-ci-eq?, string-lt?, string-gt?, string-le?,
     string-ge?, string-ci-lt?, string-ci-gt?, string-ci-le?, string-ci-ge?
-  - some predicates for `char` and `port` are defined but it always
-    returns `false`.
+  - char-eq?, char-lt?, char-gt?, char-le?, char-ge?,
+    char-ci-eq?, char-ci-lt?, char-ci-gt?, char-ci-le?, char-ci-ge?,
+	char-alphabetic?, char-numeric?, char-whitespace?,
+	char-upper-case?, char-lower-case?
+  - some predicates for `port` are defined but it always returns
+    `false`.
 
 - List operations
   - cons, car, cdr, set-car!, set-cdr!, cxxr (caar and so on)
@@ -133,6 +142,9 @@ Following procedures described in the spec is available.
 - Vector operations
   - make-vector, vector, vector-length, vector-ref, vector-set!,
     vector->list, list->vector, vector-fill!
+
+- Char operations
+  - char->integer, integer->char, char-upcase, char-downcase
 
 - Write values
   - write
@@ -169,6 +181,7 @@ deviations from the Scheme specification (R5RS or R7RS-small).
   identifier in Ruby.  So, it is possible that some collision of
   identifiers.
 - Nested definition of procedure can use outside.
+- All characters and strings are treated as encoded in UTF-8.
 
 Some of these may be disappeared in the future version, or may not be.
 

--- a/lib/rus3.rb
+++ b/lib/rus3.rb
@@ -43,6 +43,7 @@ module Rus3
 
   require_relative "rus3/procedure/utils"
   require_relative "rus3/procedure/predicate"
+  require_relative "rus3/procedure/char"
   require_relative "rus3/procedure/list"
   require_relative "rus3/procedure/vector"
   require_relative "rus3/procedure/control"

--- a/lib/rus3/char.rb
+++ b/lib/rus3/char.rb
@@ -1,6 +1,102 @@
 # frozen_string_literal: true
 
 module Rus3
+
   class Char
+    include Comparable
+
+    class << self
+
+      def alphabetic?(char)
+        raise CharRequiredError, char unless char.instance_of?(Char)
+        /[A-Za-z]/ === char.to_s
+      end
+
+      def numeric?(char)
+        raise CharRequiredError, char unless char.instance_of?(Char)
+        /[0-9]/ === char.to_s
+      end
+
+      def whitespace?(char)
+        raise CharRequiredError, char unless char.instance_of?(Char)
+        /[\s]/ === char.to_s
+      end
+
+      def upper_case?(char)
+        raise CharRequiredError, char unless char.instance_of?(Char)
+        /[A-Z]/ === char.to_s
+      end
+
+      def lower_case?(char)
+        raise CharRequiredError, char unless char.instance_of?(Char)
+        /[a-z]/ === char.to_s
+      end
+
+      def char_to_integer(char)
+        raise CharRequiredError, char unless char.instance_of?(Char)
+        char.codepoint
+      end
+
+      def integer_to_char(n, encoding: Encoding::UTF_8)
+        self.new(n.chr(encoding))
+      end
+
+      def upcase(char)
+        raise CharRequiredError, char unless char.instance_of?(Char)
+        self.new(char.to_s.upcase)
+      end
+
+      def downcase(char)
+        raise CharRequiredError, char unless char.instance_of?(Char)
+        self.new(char.to_s.downcase)
+      end
+
+      def compare_chars(char1, char2, comp_op, ignore_case: false)
+        if !char1.instance_of?(self)
+          raise CharRequiredError, char1
+        elsif !char2.instance_of?(self)
+          raise CharRequiredError, char2
+        end
+
+        if ignore_case
+          char1 = downcase(char1)
+          char2 = downcase(char2)
+        end
+        char1.send(comp_op, char2)
+      end
+
+    end
+
+    LITERAL_PREFIX  = "#\\"
+    LITERAL_SPACE   = "#\\space"
+    LITERAL_NEWLINE = "#\\newline"
+
+    attr_reader :codepoint
+    attr_reader :encoding
+
+    def initialize(str)
+      @char = str[0].dup.freeze
+      @encoding = str.encoding
+      @codepoint = @char.ord
+    end
+
+    def ==(other)
+      other.instance_of?(Char) and to_s == other.to_s
+    end
+
+    def <=>(other)
+      raise CharRequiredError, other unless other.instance_of?(Char)
+      @codepoint <=> other.codepoint
+    end
+
+    def to_literal
+      LITERAL_PREFIX + @char
+    end
+
+    def to_s
+      @char
+    end
+
   end
+
 end

--- a/lib/rus3/error.rb
+++ b/lib/rus3/error.rb
@@ -30,24 +30,61 @@ module Rus3
   # :stopdoc:
 
   EMSG = {
+    :number_required => "number required: got=%s",
+    :integer_required => "integer required: got=%s",
+    :real_number_required => "real number required: got=%s",
+    :char_required => "char required: got=%s",
+    :string_required => "string required: got=%s",
+    :vector_required => "vector required: got=%s",
     :pair_required => "pair required: got=%s",
     :list_required => "proper list required: got=%s",
     :pair_or_list_required => "pair or proper list required: got=%s",
-    :vector_required => "vector required: got=%s",
     :out_of_range  => "argument out of range: got=%s",
     :exceed_upper_limit => "argument exceeds its upper limit (%d): got=%d",
-    :unsupported_method => "specified method does not work now.",
     :wrong_type => "wrong type argument: got=%s, wants=%s",
-    :integer_required => "integer required: got=%s",
-    :real_number_required => "real number required: got=%s",
-    :number_required => "number required: got=%s",
-    :string_required => "string required: got=%s",
     :scheme_syntax_error => "syntax error as Scheme: got=%s",
+    :unsupported_method => "specified method does not work now.",
+    :unsupported_feature => "specified feature (`%s`) does not support for %s",
     :cannot_find_file => "cannot find %s",
-    :unsupported_feature => "specified feature (`%s`) does not support for %s"
   }
 
   # :startdoc:
+
+  class NumberRequiredError < Error
+    def initialize(obj)
+      super(EMSG[:number_required] % smart_error_value(obj))
+    end
+  end
+
+  class IntegerRequiredError < Error
+    def initialize(obj)
+      super(EMSG[:integer_required] % smart_error_value(obj))
+    end
+  end
+
+  class RealNumberRequiredError < Error
+    def initialize(obj)
+      super(EMSG[:real_number_required] % smart_error_value(obj))
+    end
+  end
+
+  class CharRequiredError < Error
+    def initialize(obj)
+      super(EMSG[:char_required] % smart_error_value(obj))
+    end
+  end
+
+  class StringRequiredError < Error
+    def initialize(obj)
+      super(EMSG[:string_required] % smart_error_value(obj))
+    end
+  end
+
+  class VectorRequiredError < Error
+    def initialize(obj)
+      super(EMSG[:vector_required] % smart_error_value(obj))
+    end
+  end
 
   class PairRequiredError < Error
     def initialize(obj)
@@ -67,12 +104,6 @@ module Rus3
     end
   end
 
-  class VectorRequiredError < Error
-    def initialize(obj)
-      super(EMSG[:vector_required] % smart_error_value(obj))
-    end
-  end
-
   class OutOfRangeError < Error
     def initialize(obj)
       super(EMSG[:out_of_range] % smart_error_value(obj))
@@ -85,40 +116,10 @@ module Rus3
     end
   end
 
-  class UnsupportedMethodError < Error
-    def initialize
-      super(EMSG[:unsupported_method])
-    end
-  end
-
   class WrongTypeError < Error
     def initialize(obj, expected)
       emsg = EMSG[:wrong_type] % [obj, expected]
       super(emsg)
-    end
-  end
-
-  class IntegerRequiredError < Error
-    def initialize(obj)
-      super(EMSG[:integer_required] % smart_error_value(obj))
-    end
-  end
-
-  class RealNumberRequiredError < Error
-    def initialize(obj)
-      super(EMSG[:real_number_required] % smart_error_value(obj))
-    end
-  end
-
-  class NumberRequiredError < Error
-    def initialize(obj)
-      super(EMSG[:number_required] % smart_error_value(obj))
-    end
-  end
-
-  class StringRequiredError < Error
-    def initialize(obj)
-      super(EMSG[:string_required] % smart_error_value(obj))
     end
   end
 
@@ -128,15 +129,21 @@ module Rus3
     end
   end
 
-  class CannotFindFileError < Error
-    def initialize(obj)
-      super(EMSG[:cannot_find_file] % smart_error_value(obj))
+  class UnsupportedMethodError < Error
+    def initialize
+      super(EMSG[:unsupported_method])
     end
   end
 
   class UnsupportedFeatureError < Error
     def initialize(feature, obj)
       super(EMSG[:unsupported_feature] % [feature, obj])
+    end
+  end
+
+  class CannotFindFileError < Error
+    def initialize(obj)
+      super(EMSG[:cannot_find_file] % smart_error_value(obj))
     end
   end
 

--- a/lib/rus3/evaluator.rb
+++ b/lib/rus3/evaluator.rb
@@ -16,6 +16,7 @@ module Rus3
       include Rus3::Procedure::Write
       include Rus3::Procedure::Vector
       include Rus3::Procedure::List
+      include Rus3::Procedure::Char
       include Rus3::Procedure::Predicate
       include Rus3::EmptyList
 

--- a/lib/rus3/parser/lexer.rb
+++ b/lib/rus3/parser/lexer.rb
@@ -17,6 +17,7 @@ module Rus3::Parser
       # value types
       :boolean,
       :ident,
+      :char,
       :string,
       :number,
       # operators
@@ -54,6 +55,15 @@ module Rus3::Parser
     RATIONAL   = Regexp.new("\\A[+-]?#{RAT_PAT}\\Z")
     COMPLEX    = Regexp.new("\\A[+-]?#{COMP_PAT}\\Z")
     PURE_IMAG  = Regexp.new("\\A[+-](#{C_IMAG_PAT})?i\\Z")
+
+    # char
+    SINGLE_CHAR_PAT = "."
+    SPACE_PAT       = "space"
+    NEWLINE_PAT     = "newline"
+
+    CHAR_PREFIX = "\#\\\\"
+    CHAR_PAT    = "(#{SINGLE_CHAR_PAT}|#{SPACE_PAT}|#{NEWLINE_PAT})"
+    CHAR        = Regexp.new("\\A#{CHAR_PREFIX}#{CHAR_PAT}\\Z")
 
     KEYWORDS = {
       "LAMBDA" => :lambda,
@@ -102,6 +112,8 @@ module Rus3::Parser
             else
               Token.new(:ident, literal.gsub(EXTENDED_REGEXP, EXTENDED_MAP))
             end
+          when CHAR
+            Token.new(:char, literal)
           when STRING
             Token.new(:string, literal)
           when "="

--- a/lib/rus3/parser/scheme_parser.rb
+++ b/lib/rus3/parser/scheme_parser.rb
@@ -155,7 +155,7 @@ module Rus3::Parser
         r_exp = translate_ident(token.literal)
       when :string
         r_exp = token.literal
-      when :ident, :boolean, :number, :op_proc
+      when :ident, :boolean, :char, :number, :op_proc
         trans_method_name = "translate_#{token.type}".intern
         r_exp = self.send(trans_method_name, token.literal)
       else
@@ -211,6 +211,17 @@ module Rus3::Parser
     def translate_boolean(s_exp_literal)
       # literal == "#f" or #t"
       (s_exp_literal[1] == "f") ? "false" : "true"
+    end
+
+    def translate_char(s_exp_literal)
+      c = s_exp_literal[2..-1]
+      case c
+      when "space"
+        c = " "
+      when "newline"
+        c = "\n"
+      end
+      "Char.new(\"#{c}\")"
     end
 
     def translate_number(s_exp_literal)

--- a/lib/rus3/procedure/char.rb
+++ b/lib/rus3/procedure/char.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Rus3::Procedure
+  module Char
+
+    #   - procedure (R5RS): (char->integer char)
+
+    def char_to_integer(char)
+      Rus3::Char.char_to_integer(char)
+    end
+
+    #   - procedure (R5RS): (integer->char n)
+
+    def integer_to_char(n)
+      Rus3::Char.integer_to_char(n)
+    end
+
+    #   - library procedure (R5RS): (char-upcase char)
+
+    def char_upcase(char)
+      Rus3::Char.upcase(char)
+    end
+
+    #   - library procedure (R5RS): (char-downcase char)
+
+    def char_downcase(char)
+      Rus3::Char.downcase(char)
+    end
+
+  end
+end

--- a/lib/rus3/procedure/predicate.rb
+++ b/lib/rus3/procedure/predicate.rb
@@ -72,7 +72,7 @@ module Rus3::Procedure
     end
 
     def char?(obj)
-      false
+      obj.instance_of?(Rus3::Char)
     end
 
     def string?(obj)
@@ -163,69 +163,67 @@ module Rus3::Procedure
     # :stopdoc:
 
     # Characters:
-    #
-    # ...
 
     # :startdoc:
 
     def char_eq?(char1, char2)
-      false
+      Rus3::Char.compare_chars(char1, char2, :==)
     end
 
     def char_lt?(char1, char2)
-      false
+      Rus3::Char.compare_chars(char1, char2, :<)
     end
 
     def char_gt?(char1, char2)
-      false
+      Rus3::Char.compare_chars(char1, char2, :>)
     end
 
     def char_le?(char1, char2)
-      false
+      Rus3::Char.compare_chars(char1, char2, :<=)
     end
 
     def char_ge?(char1, char2)
-      false
+      Rus3::Char.compare_chars(char1, char2, :>=)
     end
 
     def char_ci_eq?(char1, char2)
-      false
+      Rus3::Char.compare_chars(char1, char2, :==, ignore_case: true)
     end
 
     def char_ci_lt?(char1, char2)
-      false
+      Rus3::Char.compare_chars(char1, char2, :<, ignore_case: true)
     end
 
     def char_ci_gt?(char1, char2)
-      false
+      Rus3::Char.compare_chars(char1, char2, :>, ignore_case: true)
     end
 
     def char_ci_le?(char1, char2)
-      false
+      Rus3::Char.compare_chars(char1, char2, :<=, ignore_case: true)
     end
 
     def char_ci_ge?(char1, char2)
-      false
+      Rus3::Char.compare_chars(char1, char2, :>=, ignore_case: true)
     end
 
     def char_alphabetic?(char)
-      false
+      Rus3::Char.alphabetic?(char)
     end
 
     def char_numeric?(char)
-      false
+      Rus3::Char.numeric?(char)
     end
 
     def char_whitespace?(char)
-      false
+      Rus3::Char.whitespace?(char)
     end
 
     def char_upper_case?(letter)
-      false
+      Rus3::Char.upper_case?(letter)
     end
 
     def char_lower_case?(letter)
-      false
+      Rus3::Char.lower_case?(letter)
     end
 
     # :stopdoc:

--- a/lib/rus3/repl.rb
+++ b/lib/rus3/repl.rb
@@ -75,7 +75,7 @@ module Rus3
         begin
           exp = @parser.read(STDIN)     # READ
         rescue SchemeSyntaxError => e
-          puts "ERROR: %s" % e
+          puts "ERROR" + (@verbose ? "(READ)" : "")  + ": %s" % e
           next
         end
         break FAREWELL_MESSAGE if exp.nil?
@@ -83,7 +83,7 @@ module Rus3
         begin
           value = @evaluator.eval(exp)  # EVAL
         rescue SyntaxError, StandardError => e
-          puts "ERROR: %s" % e
+          puts "ERROR" + (@verbose ? "(EVAL)" : "")  + ": %s" % e
           next
         end
 

--- a/lib/rus3/version.rb
+++ b/lib/rus3/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Rus3
-  VERSION = "0.1.1"
-  RELEASE = "2021-04-22"
+  VERSION = "0.1.2"
+  RELEASE = "2021-04-23"
 end

--- a/test/rus3_char_test.rb
+++ b/test/rus3_char_test.rb
@@ -1,0 +1,214 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Rus3CharTest < Minitest::Test
+
+  def test_it_can_be_instantiated
+    ascii_ch = "a"
+    ja_ch = "あ"
+
+    ch0 = Rus3::Char.new(ascii_ch)
+    refute ch0.nil?
+
+    ch1 = Rus3::Char.new(ja_ch)
+    refute ch1.nil?
+  end
+
+  def test_it_can_be_accessed_to_codepoint
+    input = "b"
+    ch = Rus3::Char.new(input)
+    assert_equal input[0].ord, ch.codepoint
+  end
+
+  def test_it_can_be_accessed_to_encoding
+    enc = Encoding::UTF_8
+    input = "c".encode(enc)
+    ch = Rus3::Char.new(input)
+    assert_equal enc, ch.encoding
+  end
+
+  def test_it_can_be_compared_to_other_char
+    ch0 = Rus3::Char.new("d")
+    ch1 = Rus3::Char.new("e")
+    assert (ch0 <= ch1)
+  end
+
+  def test_it_raises_when_comparing_to_other_class_instance
+    ch = Rus3::Char.new("f")
+    assert_raises(Rus3::CharRequiredError) {
+      ch < "g"
+    }
+  end
+
+  def test_it_can_be_converted_into_scheme_literal
+    ch = Rus3::Char.new("h")
+    assert_equal "#\\h", ch.to_literal
+  end
+
+  def test_it_can_be_converted_into_ruby_string
+    ch = Rus3::Char.new("i")
+    assert_equal "i", ch.to_s
+  end
+
+  # class methods
+
+  def test_alphabetic_can_detect_alphabet
+    alphabets = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    alphabets.each_char { |c|
+      assert Rus3::Char.alphabetic?(Rus3::Char.new(c))
+    }
+  end
+
+  def test_alphabetic_raises_if_specified_other_than_char
+    assert_raises(Rus3::CharRequiredError) {
+      Rus3::Char.alphabetic?("A")
+    }
+  end
+
+  def test_numeric_can_detect_digit
+    digits = "0123456789"
+    digits.each_char { |c|
+      assert Rus3::Char.numeric?(Rus3::Char.new(c))
+    }
+  end
+
+  def test_numeric_raises_if_specified_other_than_char
+    assert_raises(Rus3::CharRequiredError) {
+      Rus3::Char.numeric?("0")
+    }
+  end
+
+  def test_whitespace_can_detect_space_char
+    spaces = " \t\r\n\f\v"
+    spaces.each_char { |c|
+      assert Rus3::Char.whitespace?(Rus3::Char.new(c))
+    }
+  end
+
+  def test_whitespace_raises_if_specified_other_than_char
+    assert_raises(Rus3::CharRequiredError) {
+      Rus3::Char.whitespace?(" ")
+    }
+  end
+
+  def test_uppser_case_can_detect_upper_case_char
+    uppers = "ABCDEFGHKJKLMNOPQRSTUVWXYZ"
+    lowers = "abcdefghkjklmnopqrstuvwxyz"
+
+    uppers.each_char { |c|
+      assert Rus3::Char.upper_case?(Rus3::Char.new(c))
+    }
+
+    lowers.each_char { |c|
+      refute Rus3::Char.upper_case?(Rus3::Char.new(c))
+    }
+  end
+
+  def test_upper_case_raises_if_specified_other_than_char
+    assert_raises(Rus3::CharRequiredError) {
+      Rus3::Char.upper_case?("A")
+    }
+  end
+
+  def test_lower_case_can_detect_upper_case_char
+    uppers = "ABCDEFGHKJKLMNOPQRSTUVWXYZ"
+    lowers = "abcdefghkjklmnopqrstuvwxyz"
+
+    uppers.each_char { |c|
+      refute Rus3::Char.lower_case?(Rus3::Char.new(c))
+    }
+
+    lowers.each_char { |c|
+      assert Rus3::Char.lower_case?(Rus3::Char.new(c))
+    }
+  end
+
+  def test_lower_case_raises_if_specified_other_than_char
+    assert_raises(Rus3::CharRequiredError) {
+      Rus3::Char.upper_case?("z")
+    }
+  end
+
+  def test_char_to_integer_can_convert
+    input = "a"
+    ch = Rus3::Char.new(input)
+
+    assert_equal input.ord, Rus3::Char.char_to_integer(ch)
+  end
+
+  def test_char_to_integer_raises_if_specified_other_than_char
+    assert_raises(Rus3::CharRequiredError) {
+      Rus3::Char.char_to_integer("D")
+    }
+  end
+
+  def test_integer_to_char_can_convert
+    input = "Z"
+    ch0 = Rus3::Char.new(input)
+
+    assert_equal ch0, Rus3::Char.integer_to_char(input.ord)
+  end
+
+  def test_upcase_can_convert
+    uppers = "ABCDEFGHKJKLMNOPQRSTUVWXYZ".chars
+    lowers = "abcdefghkjklmnopqrstuvwxyz".chars
+
+    lowers.each_with_index { |e, i|
+      chu = Rus3::Char.new(uppers[i])
+      chl = Rus3::Char.new(e)
+      assert_equal chu, Rus3::Char.upcase(chl)
+    }
+  end
+
+  def test_upcase_raises_if_specified_other_than_char
+    assert_raises(Rus3::CharRequiredError) {
+      Rus3::Char.upcase("f")
+    }
+  end
+
+  def test_downcase_can_convert
+    uppers = "ABCDEFGHKJKLMNOPQRSTUVWXYZ".chars
+    lowers = "abcdefghkjklmnopqrstuvwxyz".chars
+
+    uppers.each_with_index { |e, i|
+      chu = Rus3::Char.new(e)
+      chl = Rus3::Char.new(lowers[i])
+      assert_equal chl, Rus3::Char.downcase(chu)
+    }
+  end
+
+  def test_downcase_raises_if_specified_other_than_char
+    assert_raises(Rus3::CharRequiredError) {
+      Rus3::Char.downcase("G")
+    }
+  end
+
+  def test_compare_chars_can_compare
+    ops = [:==, :<, :>, :<=, :>=]
+    char1 = Rus3::Char.new("H")
+    char2 = Rus3::Char.new("i")
+    expected = [false, true, false, true, false]
+
+    ops.each_with_index { |op, i|
+      result = Rus3::Char.compare_chars(char1, char2, op)
+      assert_equal expected[i], result
+    }
+  end
+
+  def test_compare_chars_raises_if_specified_other_than_char_as_1st_arg
+    ch = Rus3::Char.new("j")
+    assert_raises(Rus3::CharRequiredError) {
+      Rus3::Char.compare_chars("j", ch, :==)
+    }
+  end
+
+  def test_compare_chars_raises_if_specified_other_than_char_as_2nd_arg
+    ch = Rus3::Char.new("j")
+    assert_raises(Rus3::CharRequiredError) {
+      Rus3::Char.compare_chars(ch, "j", :==)
+    }
+  end
+
+end

--- a/test/rus3_parser_lexer_test.rb
+++ b/test/rus3_parser_lexer_test.rb
@@ -28,6 +28,13 @@ class Rus3ParserLexerTest < Minitest::Test
     refute_token_type(tcs, :ident)
   end
 
+  # char
+
+  def test_it_can_detect_char
+    tcs = ["#\\a", "#\\space", "#\\newline"]
+    assert_token_type(tcs, :char)
+  end
+
   # string
 
   def test_it_can_detect_a_string

--- a/test/rus3_parser_scheme_parser_test.rb
+++ b/test/rus3_parser_scheme_parser_test.rb
@@ -26,6 +26,15 @@ class Rus3ParserSchemeParserTest < Minitest::Test
     assert_expected(expected)
   end
 
+  def test_it_can_translate_literal_char
+    expected = {
+      "#\\a" => "Char.new(\"a\")",
+      "#\\space" => "Char.new(\" \")",
+      "#\\newline" => "Char.new(\"\n\")",
+    }
+    assert_expected(expected)
+  end
+
   def test_it_can_translate_literal_string
     expected = { '"hoge"' => '"hoge"', '"りすぷ"' => '"りすぷ"', }
     assert_expected(expected)

--- a/test/rus3_procedure_predicate_test.rb
+++ b/test/rus3_procedure_predicate_test.rb
@@ -220,7 +220,58 @@ class Rus3ProcedurePredicateTest < Minitest::Test
   end
 
   # character
-  # TODO: write tests when Char class was defined.
+
+  def test_char_succeeds_against_char
+    assert char?(Rus3::Char.new("%"))
+  end
+
+  def test_char_fails_other_than_char
+    prepare_values_except(:char).each { |value|
+      char?(value)
+    }
+  end
+
+  # character comparison
+
+  def test_char_comparison_work_fine
+    char1 = Rus3::Char.new("A")
+    char2 = Rus3::Char.new("a")
+
+    expected = {
+      eq: false, lt: true, gt: false, le: true, ge: false,
+      ci_eq: true, ci_lt: false, ci_gt: false, ci_le: true, ci_ge: true,
+    }
+
+    expected.each { |k, v|
+      method_symbol = "char_#{k}?".intern
+      m = method(method_symbol)
+      assert_equal v, m.call(char1, char2)
+    }
+  end
+
+  def test_char_detect_type_work_fine
+    true_cases = "k8\tLm".chars
+    false_cases = "&nopQ".chars
+
+    predicates = [
+      :char_alphabetic?,
+      :char_numeric?,
+      :char_whitespace?,
+      :char_upper_case?,
+      :char_lower_case?,
+    ]
+
+    0.upto(true_cases.size - 1).each { |i|
+      ch = Rus3::Char.new(true_cases[i])
+      assert method(predicates[i]).call(ch)
+    }
+
+    0.upto(false_cases.size - 1).each { |i|
+      ch = Rus3::Char.new(false_cases[i])
+      refute method(predicates[i]).call(ch)
+    }
+
+  end
 
   # string
 
@@ -266,7 +317,7 @@ class Rus3ProcedurePredicateTest < Minitest::Test
     :pair      => Rus3::Pair.new(1, 2),
     :symbol    => :foo,
     :number    => Math::PI,
-    :char      => :not_ready,
+    :char      => Rus3::Char.new("$"),
     :string    => "hoge",
     :vector    => :not_ready,
     :port      => :not_ready,


### PR DESCRIPTION
- add Rus3::Char and Rus3::Procedure::Char
  - modify Rus3::Parser::Lexer and Rus3::Parser::SchemeParser to
    accept a character literal
  - add new error classes (Rus3::CharRequiredError)
  - add tests for characters and its operations
- update README.md about characters
- bump version: 0.1.1 -> 0.1.2