### PR TITLE
feat: add a mechanism to replace comparison operator characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
-- (nothing to record)
+- Add a mechanism to replace comparison operator characters in
+  identifiers.
+  - e.g. `char<?` -> `char_lt?`
 
 ## [0.1.2] - 2021-04-23
 ### Added

--- a/lib/rus3/parser/scheme_parser.rb
+++ b/lib/rus3/parser/scheme_parser.rb
@@ -151,7 +151,7 @@ module Rus3::Parser
     def parse_primitive(token)
       r_exp = nil
       case token.type
-      when *Lexer::KEYWORDS.values
+      when *Lexer::SCM_KEYWORDS.values
         r_exp = translate_ident(token.literal)
       when :string
         r_exp = token.literal
@@ -203,6 +203,50 @@ module Rus3::Parser
       }
       i_exp
     end
+
+    RB_KEYWORDS = {
+      "BEGIN"    => nil,
+      "END"      => nil,
+      "alias"    => nil,
+      "and"      => nil,
+      "begin"    => nil,
+      "break"    => nil,
+      "case"     => nil,
+      "class"    => nil,
+      "def"      => nil,
+      "defined?" => nil,
+      "do"       => nil,
+      "else"     => nil,
+      "elsif"    => nil,
+      "end"      => nil,
+      "ensure"   => nil,
+      "false"    => nil,
+      "for"      => nil,
+      "if"       => nil,
+      "in"       => nil,
+      "module"   => nil,
+      "next"     => nil,
+      "nil"      => nil,
+      "not"      => nil,
+      "or"       => nil,
+      "redo"     => nil,
+      "rescue"   => nil,
+      "retry"    => nil,
+      "return"   => nil,
+      "self"     => nil,
+      "super"    => nil,
+      "then"     => nil,
+      "true"     => nil,
+      "undef"    => nil,
+      "unless"   => nil,
+      "until"    => nil,
+      "when"     => nil,
+      "while"    => nil,
+      "yield"    => nil,
+      "__LINE__" => nil,
+      "__FILE__" => nil,
+      "__ENCODING__" => nil,
+    }
 
     def translate_ident(s_exp_literal)
       "#{s_exp_literal}"

--- a/test/rus3_parser_lexer_test.rb
+++ b/test/rus3_parser_lexer_test.rb
@@ -150,6 +150,29 @@ class Rus3ParserLexerTest < Minitest::Test
     }
   end
 
+  # replace extended characters
+
+  def test_it_can_convert_comparison_chars
+    test_cases = {
+      "char=?" => "char_eq?",
+      "char<?" => "char_lt?",
+      "char>?" => "char_gt?",
+      "char<=?" => "char_le?",
+      "char>=?" => "char_ge?",
+      "char-ci=?" => "char_ci_eq?",
+      "char-ci<?" => "char_ci_lt?",
+      "char-ci>?" => "char_ci_gt?",
+      "char-ci<=?" => "char_ci_le?",
+      "char-ci>=?" => "char_ci_ge?",
+    }
+    test_cases.each { |input, expected|
+      l = Rus3::Parser::Lexer.new(input)
+      token = l.next
+      assert_equal :ident, token.type
+      assert_equal expected, token.literal
+    }
+  end
+
   private
 
   def assert_token_type(test_cases, expected_type)


### PR DESCRIPTION
- modify to replace comparison characters in a identifier
- modify some constants name in Rus3::Parser::Lexer
- add a test for the replacement of comparison characters